### PR TITLE
Remove instances of curl from Dockerfile

### DIFF
--- a/ubi8-py38/BUILDING.md
+++ b/ubi8-py38/BUILDING.md
@@ -1,0 +1,23 @@
+* This Dockerfile requires the parent directory as the context since it pulls
+some files from there. To build, use this command
+
+podman build -f ./Dockerfile ..
+
+From an OpenShift buildConfig, do something like this to leave the context
+set in the parent directory but change the Dockerfile path
+
+```
+  source:
+    git:
+      ref: master
+      uri: https://github.com/red-hat-data-services/s2i-thoth
+    type: Git
+  strategy:
+    dockerStrategy:
+      dockerfilePath: ubi8-py38/Dockerfile
+      from:
+        kind: ImageStreamTag
+        name: mygreatimage
+      noCache: true
+    type: Docker
+```

--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -25,15 +25,20 @@ LABEL summary="$SUMMARY" \
     maintainer="Thoth Station <aicoe-thoth@redhat.com>"
 
 USER 0
-COPY ./s2i_assemble.patch /tmp/s2i_assemble.patch
+COPY ubi8-py38/s2i_assemble.patch /tmp/s2i_assemble.patch
+
+COPY ubi8-py38/requirements.txt .
+
+COPY assemble .
+
 RUN TMPFILE=$(mktemp) && \
     TMPFILE_ASSEMBLE=$(mktemp) && \
     pushd "${STI_SCRIPTS_PATH}" && patch -p 1 </tmp/s2i_assemble.patch && popd && \
     pip3 install -U "pip==20.3.3" && \
     /usr/bin/pip3 install -U "pip==20.3.3" && \
-    curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/ubi8-py38/requirements.txt" -o requirements.txt && \
-    MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 curl https://raw.githubusercontent.com/thoth-station/micropipenv/master/micropipenv.py | /usr/bin/python3 - install -- && \
-    curl "https://raw.githubusercontent.com/thoth-station/s2i-thoth/master/assemble" -o "${TMPFILE_ASSEMBLE}" && \
+    /usr/bin/pip3 install -U "micropipenv" && \
+    MICROPIPENV_NO_LOCKFILE_WRITE=1 MICROPIPENV_PIP_BIN=/usr/bin/pip3 micropipenv install && \
+    cp assemble "${TMPFILE_ASSEMBLE}" && \
     cp "${STI_SCRIPTS_PATH}/assemble" "${TMPFILE}" && \
     head -n1 "${TMPFILE}" >"${STI_SCRIPTS_PATH}/assemble" && \
     cat "${TMPFILE_ASSEMBLE}" >>"${STI_SCRIPTS_PATH}/assemble" && \


### PR DESCRIPTION
* build needs to be run with parent directory as context
* micropipenv installed from pypi instead of curled from thoth
* assemble and requirements.txt copied from local directory
  and parent directory instead of curling from s2i-thoth

## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

<!--- Describe your changes in detail -->
