### PR TITLE
Do not yum update on ubi8-py38

### DIFF
--- a/ubi8-py38/Dockerfile
+++ b/ubi8-py38/Dockerfile
@@ -46,7 +46,6 @@ RUN TMPFILE=$(mktemp) && \
     rm "${TMPFILE}" "${TMPFILE_ASSEMBLE}" /tmp/s2i_assemble.patch requirements.txt && \
     sed -i '/  echo "---> Running application from .*/d' "${STI_SCRIPTS_PATH}/run" && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} -P && \
-    yum update --assumeyes --nobest --setopt=tsflags=nodocs
+    fix-permissions ${APP_ROOT} -P
 
 USER 1001


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-3705
- [ ] The Jira story is acked
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

First of all, delete the previous build chain objects:

```
$ oc delete is -l "rhods/buildchain=cuda" -n redhat-ods-applications
$ oc delete bc -l "rhods/buildchain=cuda" -n redhat-ods-applications
```

Create a new build chain with the patch:

```
$ oc apply -n redhat-ods-applications -f https://raw.githubusercontent.com/samuelvl/odh-deployer/rhods-3705/jupyterhub/cuda-11.4.2/manifests.yaml
```
